### PR TITLE
feat(devfile): update image for dev container

### DIFF
--- a/devfile.yaml
+++ b/devfile.yaml
@@ -4,7 +4,7 @@ metadata:
 components:
   - name: tools
     container:
-      image: registry.access.redhat.com/ubi8/openjdk-11 
+      image: registry.redhat.io/codeready-workspaces/plugin-java11-rhel8 
       env:
         - name: QUARKUS_HTTP_HOST
           value: 0.0.0.0


### PR DESCRIPTION
Signed-off-by: svor <vsvydenk@redhat.com>

Use registry.redhat.io/codeready-workspaces/plugin-java11-rhel8 image in dev container to avoid terminating problem

![quarkus](https://user-images.githubusercontent.com/1271546/149765335-279ca6d8-250f-4afa-8def-b6d3768af913.png)

### Related issue:
https://issues.redhat.com/browse/CRW-2650