### PR TITLE
Use UDI in devfile

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,12 @@
+{
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "type": "java",
+            "request": "attach",
+            "name": "Attach to Remote Quarkus App",
+            "hostName": "localhost",
+            "port": 5005
+        }
+    ]
+}

--- a/devfile.yaml
+++ b/devfile.yaml
@@ -4,7 +4,7 @@ metadata:
 components:
   - name: tools
     container:
-      image: registry.redhat.io/codeready-workspaces/plugin-java11-rhel8 
+      image: registry.redhat.io/codeready-workspaces/udi-rhel8 
       env:
         - name: QUARKUS_HTTP_HOST
           value: 0.0.0.0
@@ -17,24 +17,12 @@ components:
           name: hello-greeting-endpoint
           protocol: http
           targetPort: 8080
-          path: /hello/greeting/che-user
+          path: /hello/greeting/crw-user
       volumeMounts:
         - name: m2
-          path: /home/jboss/.m2
+          path: /home/user/.m2
       memoryLimit: 4G
       mountSources: true
-
-  - name: ubi-minimal
-    container:
-      image: registry.access.redhat.com/ubi8/ubi-minimal
-      command: ['tail']
-      args: ['-f', '/dev/null']
-      memoryLimit: 64M
-      mountSources: true
-
-  - name: gradle
-    volume:
-      size: 1G
   - name: m2
     volume:
       size: 1G
@@ -42,34 +30,17 @@ commands:
   - id: package
     exec:
       component: tools
-      workingDir: ${PROJECTS_ROOT}/quarkus-quickstarts/getting-started
+      workingDir: ${PROJECT_SOURCE}/getting-started
       commandLine: "./mvnw package"
       group:
         kind: build
         isDefault: true
-  - id: packagenative
-    exec:
-      label: "Package Native"
-      component: tools
-      workingDir: ${PROJECTS_ROOT}/quarkus-quickstarts/getting-started
-      commandLine: "./mvnw package -Dnative -Dmaven.test.skip -Dquarkus.native.native-image-xmx=2G"
-      group:
-        kind: build
   - id: startdev
     exec:
       label: "Start Development mode (Hot reload + debug)"
       component: tools
-      workingDir: ${PROJECTS_ROOT}/quarkus-quickstarts/getting-started
+      workingDir: ${PROJECT_SOURCE}/getting-started
       commandLine: "./mvnw compile quarkus:dev"
       group:
         kind: run
         isDefault: true
-
-  - id: startnative
-    exec:
-      label: "Start Native"
-      component: ubi-minimal
-      workingDir: ${PROJECTS_ROOT}/quarkus-quickstarts/getting-started/target
-      commandLine: "./getting-started-1.0.0-SNAPSHOT-runner"
-      group:
-        kind: run


### PR DESCRIPTION
- Add UDI;
- Add debug config;
- Remove native related commands to make it equal to devfile v1
- Use PROJECT_SOURCE instead of PROJSCTS_ROOT

![screenshot-codeready-openshift-operators apps cluster-7568 7568 sandbox1862 opentlc com-2022 02 09-18_13_41](https://user-images.githubusercontent.com/1271546/153242189-57978c4b-8a40-4ae1-8753-638c7f63e8ae.png)


@nickboldt @vinokurig Two moments here, let me know what you think about it:

- These changes will **brake** Quarkus DevWorkspace in CRW 2.15 because **registry.redhat.io/codeready-workspaces/udi-rhel8** is not published yet
- I've added UDI without tag. I think tag should be added during the DevWorkspace template generation with correct version, in this script https://github.com/redhat-developer/codeready-workspaces/blob/crw-2-rhel-8/dependencies/che-devfile-registry/build/scripts/generate_devworkspace_templates.sh.



