### PR TITLE
chore: replace mvnw with mvn in the devfile

### DIFF
--- a/devfile.yaml
+++ b/devfile.yaml
@@ -31,7 +31,7 @@ commands:
     exec:
       component: tools
       workingDir: ${PROJECTS_ROOT}/quarkus-quickstarts/getting-started
-      commandLine: "./mvnw package"
+      commandLine: "mvn package"
       group:
         kind: build
         isDefault: true
@@ -40,7 +40,7 @@ commands:
       label: "Start Development mode (Hot reload + debug)"
       component: tools
       workingDir: ${PROJECTS_ROOT}/quarkus-quickstarts/getting-started
-      commandLine: "./mvnw compile quarkus:dev"
+      commandLine: "mvn compile quarkus:dev"
       group:
         kind: run
         isDefault: true


### PR DESCRIPTION
Signed-off-by: Valerii Svydenko <vsvydenk@redhat.com>

Use local maven to build and run sample instead of maven wrapper.

Tested on disconnected env:

![screenshot-devspaces-openshift-devspaces apps crw-airgap-v10 crw-qe com-2022 07 11-20_39_08](https://user-images.githubusercontent.com/1271546/178325555-bf8ae881-69c0-4649-b997-91bcd6beb5ed.png)


Related issue: https://issues.redhat.com/browse/CRW-3038