### PR TITLE
chore: add missing java related extensions

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -2,6 +2,11 @@
   // See https://go.microsoft.com/fwlink/?LinkId=827846
   // for the documentation about the extensions.json format
   "recommendations": [
-    "redhat.vscode-quarkus"
+    "redhat.java",
+    "vscjava.vscode-java-debug",
+    "vscjava.vscode-java-test",
+    "redhat.vscode-microprofile",
+    "redhat.vscode-quarkus",
+    "redhat.fabric8-analytics"
   ]
 }


### PR DESCRIPTION
Signed-off-by: Vitaliy Gulyy <vgulyy@redhat.com>

`redhat.vscode-quarkus` pluin in che plugin registry depends on
  - `redhat/java`
  - `redhat/vscode-microprofile`
  - `vscjava/vscode-java-debug`
  - `vscjava/vscode-java-test`
  
In che-theia editor all there extensions are installed automatically. To have the consistent workspace with che-code editor, it needs to add corresponding extensions for that plugins.
 
It needs to add `redhat.fabric8-analytics`  as well.
 
Solves https://issues.redhat.com/browse/CRW-3302, https://issues.redhat.com/browse/CRW-3216

Use following URI to create a workspace with factory
https://github.com/vitaliy-guliy/quarkus-quickstarts?che-editor=che-incubator/che-code/insiders
