### PR TITLE
chore: use https protocol in endpoint

### DIFF
--- a/devfile.yaml
+++ b/devfile.yaml
@@ -15,7 +15,7 @@ components:
           targetPort: 5005
         - exposure: public
           name: hello-greeting-endpoint
-          protocol: http
+          protocol: https
           targetPort: 8080
           path: /hello/greeting/devspaces-user
       volumeMounts:


### PR DESCRIPTION
use https protocol in endpoint

![screenshot-devspaces apps sandbox-m4 g2pi p1 openshiftapps com-2023 12 21-14_58_55](https://github.com/devspaces-samples/quarkus-quickstarts/assets/1271546/31ebce8c-a290-444d-a39f-3526167705e9)

Related issue: https://issues.redhat.com/browse/CRW-5377