### PR TITLE
set devfile's schemaVersion to 2.2.2

### DIFF
--- a/devfile.yaml
+++ b/devfile.yaml
@@ -1,4 +1,4 @@
-schemaVersion: 2.1.0
+schemaVersion: 2.2.2
 metadata:
   name: quarkus-quickstart
 components:
@@ -14,7 +14,7 @@ components:
           protocol: tcp
           targetPort: 5005
         - exposure: public
-          name: hello-greeting-endpoint
+          name: hello-greeting
           protocol: https
           targetPort: 8080
           path: /hello/greeting/devspaces-user


### PR DESCRIPTION
Updates devfile's schemaVersion to 2.2.2

Related issue: https://github.com/eclipse/che/issues/21985

![screenshot-devspaces apps sandbox-stage gb17 p1 openshiftapps com-2024 02 01-15_49_50](https://github.com/devspaces-samples/quarkus-quickstarts/assets/1271546/bd428a6a-a85f-43c7-a897-eff886a50a2d)

